### PR TITLE
Fix avatar prop name

### DIFF
--- a/src/components/workspace/InviteModal.tsx
+++ b/src/components/workspace/InviteModal.tsx
@@ -7,7 +7,7 @@ import { useUserSearch } from "@/hooks/useUserSearch"
 import { useAddWorkspaceUser } from "@/hooks/useAddWorkspaceUser"
 
 interface InviteModalProps {
-  avaterUrl?: string
+  avatarUrl?: string
   displayName?: string
   username?: string
   id?: string


### PR DESCRIPTION
## Summary
- fix `avaterUrl` typo in `InviteModalProps`

## Testing
- `yarn lint` *(fails: package missing)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ec39742c832885ef632dce35cb26