### PR TITLE
Fix useForm watch hook

### DIFF
--- a/src/components/chat/MessageComposer.tsx
+++ b/src/components/chat/MessageComposer.tsx
@@ -25,10 +25,10 @@ export default function MessageComposer({ channelId }: { channelId: string }) {
     register,
     handleSubmit,
     reset,
+    watch,
     formState: { isSubmitting },
   } = useForm<FormData>({ resolver: zodResolver(schema) })
 
-  const { watch } = useForm<FormData>()
   const content = watch("content") // reactive value
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- clean up `MessageComposer` form logic by removing the extra `useForm`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f1b608648328952b464faf43e9f5